### PR TITLE
Small build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ BINDIR ?= $(PREFIX)/bin
 
 CFLAGS += -Iinclude -Isys/share/libtre -DDLBLIB -DWIZARD=\"$(shell whoami)\" -DSLASHEM_GIT_COMMIT_REV=\"$(shell git rev-parse --short HEAD)\"
 CFLAGS += -g -ggdb -O0 -pipe
-CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -Wall -Wimplicit-fallthrough
+CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -Wall -Wimplicit-fallthrough -U_FORTIFY_SOURCE
+# If you want to build with _FORTIFY_SOURCE warnings enabled, you will need to turn
+# some of them off (and turn on optimization) below.
+#CFLAGS += -D_FORTIFY_SOURCE -O -Wno-format-overflow -Wno-maybe-uninitialized -Wno-format-truncation -Wno-unused-result
 
 ifneq ($(CC),tcc)
 	CFLAGS += -Werror

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CFLAGS += -g -ggdb -O0 -pipe
 CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -Wall -Wimplicit-fallthrough -U_FORTIFY_SOURCE
 # If you want to build with _FORTIFY_SOURCE warnings enabled, you will need to turn
 # some of them off (and turn on optimization) below.
-#CFLAGS += -D_FORTIFY_SOURCE -O -Wno-format-overflow -Wno-maybe-uninitialized -Wno-format-truncation -Wno-unused-result
+#CFLAGS += -D_FORTIFY_SOURCE -O -Wno-format-overflow -Wno-maybe-uninitialized -Wno-format-truncation
 
 ifneq ($(CC),tcc)
 	CFLAGS += -Werror

--- a/include/permonst.h
+++ b/include/permonst.h
@@ -39,7 +39,7 @@ struct attack {
 #include "monflag.h"
 
 struct permonst {
-	const char mname[32];	    /* full name */
+	char mname[32];	            /* full name */
 	uchar mlet;		    /* symbol */
 	schar mlevel,		    /* base monster level */
 		mmove,		    /* move speed */

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -5,6 +5,7 @@
 
 /* We could include only config.h, except for the overlay definitions... */
 #include "hack.h"
+#include <assert.h>
 
 #ifdef __FreeBSD__
 #define __XSI_VISIBLE 500  //gettimeofday()
@@ -409,7 +410,7 @@ void setrandom(void) {
 	}
 
 	if (fp) {
-		fread(rnbuf, 32, 1, fp);
+		assert(fread(rnbuf, 32, 1, fp) > 0);
 		fclose(fp);
 	}
 

--- a/sys/unix/unixunix.c
+++ b/sys/unix/unixunix.c
@@ -12,6 +12,7 @@
 #include <fcntl.h>
 #endif
 #include <signal.h>
+#include <assert.h>
 
 static int veryold(int);
 static int eraseoldlocks(void);
@@ -215,10 +216,10 @@ int child(int wt) {
 	suspend_nhwindows(NULL);	/* also calls end_screen() */
 
 	if ((f = fork()) == 0) {		/* child */
-		setgid(getgid());
-		setuid(getuid());
+		assert(setgid(getgid()) == 0);
+		assert(setuid(getuid()) == 0);
 #ifdef CHDIR
-		chdir(getenv("HOME"));
+		assert(chdir(getenv("HOME")) == 0);
 #endif
 		return 1;
 	}

--- a/util/recover.c
+++ b/util/recover.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include "win32api.h"
 #endif
+#include <assert.h>
 
 int restore_savefile(char *);
 void set_levelfile_name(int);
@@ -260,7 +261,7 @@ int
 			if (lfd >= 0) {
 				/* any or all of these may not exist */
 				levc = (xchar)lev;
-				write(sfd, &levc, sizeof(levc));
+				assert(write(sfd, &levc, sizeof(levc)) > 0);
 				copy_bytes(lfd, sfd);
 				close(lfd);
 				unlink(lock);


### PR DESCRIPTION
Three changes, take whichever ones you like:
- fix "assignment of readonly variable" error introduced recently when moving from char* to char[]
- disable _FORTIFY_SOURCE in the makefile since it's enabled by default on some systems and slashem9 doesn't build if it's enabled
- fix some of the warnings reported by _FORTIFY_SOURCE

The last of these takes a very blunt-instrument approach (wrap the potentially failing calls in assert); I'm not sure if you want a more sophisticated approach to that.